### PR TITLE
Fix nested TypeParameterApplication validation

### DIFF
--- a/packages/flow-runtime/src/__tests__/__fixtures__/bugs/197-deep-object-and-array-types.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/bugs/197-deep-object-and-array-types.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  const ItemType = t.type('ItemType', t.object(t.property('designation', t.string()), t.property('price', t.number(), true), t.property('weight', t.number(), true)));
+  const ParcelType = t.type('ParcelType', ParcelType => {
+    const CustomItemType = ParcelType.typeParameter('CustomItemType');
+    return t.object(t.property('nbItems', t.number()), t.property('item', CustomItemType));
+  });
+  const ParcelsDeliveryType = t.type('ParcelsDeliveryType', ParcelsDeliveryType => {
+    const CustomParcelType = ParcelsDeliveryType.typeParameter('CustomParcelType');
+    return t.object(t.property('parcels', t.array(CustomParcelType)), t.property('country', t.string()));
+  });
+
+
+  const shirt = ItemType.assert({
+    designation: 'shirt',
+    price: 20,
+    weight: 0.5
+  });
+
+  const freeGoodie = ItemType.assert({
+    designation: 'goodie',
+    weight: 0.01
+  });
+
+  return t.ref(ParcelsDeliveryType, t.ref(ParcelType, ItemType)).assert({
+    country: 'FRANCE',
+    parcels: [{
+      nbItems: 2,
+      item: shirt
+    }, {
+      nbItems: 1,
+      item: freeGoodie
+    }]
+  });
+}

--- a/packages/flow-runtime/src/types/TypeParameter.js
+++ b/packages/flow-runtime/src/types/TypeParameter.js
@@ -4,6 +4,7 @@ import Type from './Type';
 import compareTypes from '../compareTypes';
 import FlowIntoType from "./FlowIntoType";
 import TypeAlias from './TypeAlias';
+import TypeParameterApplication from './TypeParameterApplication'
 
 import type Validation, {ErrorTuple, IdentifierPath} from '../Validation';
 
@@ -32,7 +33,7 @@ export default class TypeParameter<T> extends Type {
     const boundOrDefault = this.bound || this.default;
     const {recorded, context} = this;
 
-    if (boundOrDefault instanceof FlowIntoType || boundOrDefault instanceof TypeAlias) {
+    if (boundOrDefault instanceof FlowIntoType || boundOrDefault instanceof TypeAlias || boundOrDefault instanceof TypeParameterApplication) {
       // We defer to the other type parameter so that values from this
       // one can flow "upwards".
       yield* boundOrDefault.errors(validation, path, input);
@@ -65,7 +66,7 @@ export default class TypeParameter<T> extends Type {
   accepts (input: any): boolean {
     const boundOrDefault = this.bound || this.default;
     const {recorded, context} = this;
-    if (boundOrDefault instanceof FlowIntoType || boundOrDefault instanceof TypeAlias) {
+    if (boundOrDefault instanceof FlowIntoType || boundOrDefault instanceof TypeAlias || boundOrDefault instanceof TypeParameterApplication) {
       // We defer to the other type parameter so that values from this
       // one can flow "upwards".
       return boundOrDefault.accepts(input);


### PR DESCRIPTION
fix #197 

@phpnode I *think* this is the correct fix, as all of the tests now pass, but the complexity of how `recorded` works makes me nervous, as I don't fully understand what it's intended for.  Is it okay to always ignore `recorded` if `bound` is a `TypeParameterApplication`?