### PR TITLE
name_mapper works with matching groups

### DIFF
--- a/packages/flow-config-parser/src/__tests__/flowConfigParser.test.js
+++ b/packages/flow-config-parser/src/__tests__/flowConfigParser.test.js
@@ -49,4 +49,22 @@ describe('Flow Config Parser', function () {
 
     deepEqual(result.get('version'), ['0.23.1']);
   });
+
+  it('should allow replacements to work correctly in name_mapper', () => {
+    const result = parse(`
+      [ignore]
+
+      [include]
+
+      [lib]
+
+      [options]
+      module.name_mapper='some/matching/(.*)/group' -> 'replaced/\\1/group'
+    `);
+
+    equal(
+      result.remapModule('some/matching/test/group'),
+      'replaced/test/group',
+    );
+  });
 });

--- a/packages/flow-config-parser/src/flowConfigParser.js
+++ b/packages/flow-config-parser/src/flowConfigParser.js
@@ -84,7 +84,10 @@ export default function parseFlowConfig (input: string, projectRoot: string = pr
         if (KNOWN_REGEXPS[sectionName] && KNOWN_REGEXPS[sectionName][key]) {
           const matchesMapper = /^\s*'(.*)'\s*->\s*'(.*)'$/.exec(value);
           if (matchesMapper) {
-            value = [regexpify(matchesMapper[1]), matchesMapper[2]];
+            value = [
+              regexpify(matchesMapper[1]),
+              matchesMapper[2].replace(/\\(\d)/g, '$$$1').replace(/<PROJECT_ROOT>/g, process.cwd()),
+            ];
           }
           else {
             value = regexpify(value);
@@ -170,7 +173,7 @@ export class FlowConfig {
     const mappers = this.get('module.name_mapper');
     for (const [pattern, redirect] of mappers) {
       if (pattern.test(name)) {
-        return redirect;
+        return name.replace(pattern, redirect);
       }
     }
     return name;


### PR DESCRIPTION
The `.flowconfig` can accept replacements based on a matching group on the right-hand-side of `module.name_mapper`.

For instance,

```
module.name_mapper= 'test/\(.*\)' -> 'another/\1'
```

when importing like `import type { Thing } from 'test/something';`, flow will look for the import in `import type { Thing } from 'another/something';`

I have made the `remapModule` function work for that case, too.