### PR TITLE
Remap module names based on config

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/loadFlowConfig.js
+++ b/packages/babel-plugin-flow-runtime/src/loadFlowConfig.js
@@ -1,17 +1,17 @@
 /* @flow */
 
 import parseFlowConfig from 'flow-config-parser';
-import {fs} from './util';
+import fs from 'fs';
 import path from 'path';
 
-export default async function loadFlowConfig (startDir: string = process.cwd()) {
+export default function loadFlowConfig (startDir: string = process.cwd()) {
   let dirname = startDir;
   while (dirname) {
     try {
       const filename = path.join(dirname, '.flowconfig');
-      const stat = await fs.statAsync(filename);
+      const stat = fs.statSync(filename);
       if (stat.isFile()) {
-        const content = fs.readFileAsync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         return parseFlowConfig(content);
       }
     }


### PR DESCRIPTION
Currently, the babel module ignores the config. This doesn't work if the module names are remapped to some meaningful place, and means the types remain undefined.

Here, we map the module to it's location inside of `.flowconfig` if it is a type import.