### PR TITLE
Add PURE annotation to generated typedef

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -49,10 +49,14 @@ export default function transformVisitors (context: ConversionContext): Object {
           declarations.push(t.variableDeclaration('const', [
             t.variableDeclarator(
               t.identifier(name),
-              context.call('tdz', t.arrowFunctionExpression(
-                [],
-                replacement
-              ))
+              t.addComment(
+                context.call('tdz', t.arrowFunctionExpression(
+                  [],
+                  replacement
+                )),
+                'leading',
+                '@__PURE__'
+              )
             )
           ]));
         }


### PR DESCRIPTION
Marking this statement as pure provides a workaround for #239 via live code inclusion/treeshaking and the disabling of function annotations. For example, a [rollup](https://rollupjs.org/guide/en/) configuration object like this will fully prune usage of `flow-aws-lambda` with `annotate: false` configured:

```js
import babel from 'rollup-plugin-babel';

export default {
  input: './index.js',
  output: {
    file: './dist/index.js',
    format: 'cjs',
  },
  external: ['flow-aws-lambda'],
  treeshake: {
    pureExternalModules: true,
  },
  plugins: [
    babel({
      plugins: [['flow-runtime', { annotate: false }]],
      presets: ['@babel/preset-flow'],
    }),
  ],
};
```