### PR TITLE
Fix for #245 : ignore exact flag on error checks if object has indexers

### DIFF
--- a/packages/flow-runtime/src/__tests__/__fixtures__/bugs/245-dictionary-objects.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/bugs/245-dictionary-objects.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass(t: TypeContext) {
+  // { [string]: ?string }
+  const nonExactType = t.exactObject(t.indexer("key", t.string(), t.nullable(t.string())))
+  nonExactType.assert( { a: 'a' } );
+
+  // {| [string]: ?string |}
+  const exactType = t.exactObject(t.indexer("key", t.string(), t.nullable(t.string())))
+  return exactType.assert( { a: 'a' } );
+}
+
+export function fail(t: TypeContext) {
+  // {| [string]: ?string |}
+  const type = t.exactObject(t.indexer("key", t.string(), t.nullable(t.string())))
+  return type.assert( { a: {} } );
+}

--- a/packages/flow-runtime/src/types/ObjectType.js
+++ b/packages/flow-runtime/src/types/ObjectType.js
@@ -147,9 +147,11 @@ export default class ObjectType<T: {}> extends Type {
     }
     else {
       yield* collectErrorsWithoutIndexers(this, validation, path, input);
-    }
-    if (this.exact) {
-      yield* collectErrorsExact(this, validation, path, input);
+
+      // exact with indexer is same as non-exact
+      if (this.exact) {
+        yield* collectErrorsExact(this, validation, path, input);
+      }
     }
     validation.endCycle(this, input);
   }


### PR DESCRIPTION
Fix for https://github.com/gajus/flow-runtime/issues/245 : ignore exact flag on error checks if object has indexers