### PR TITLE
For #2: Add explicit return (with assetion) if last function statement is not return one

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/2-explicit-function-return.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/2-explicit-function-return.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+export const input = `
+function testFunction() : string {
+  return;
+}
+`;
+
+export const expected = `
+import t from "flow-runtime";
+
+function testFunction() {
+  const _returnType = t.return(t.string());
+  return _returnType.assert();
+}
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/2-implicit-function-return.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/2-implicit-function-return.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+export const input = `
+function testFunction() : string {
+
+}
+`;
+
+export const expected = `
+import t from "flow-runtime";
+
+function testFunction() {
+  const _returnType = t.return(t.string());
+  return _returnType.assert();
+}
+`;

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -507,6 +507,19 @@ export default function transformVisitors (context: ConversionContext): Object {
                 context.call('return', convert(context, returnType))
               )
             ]));
+
+            // explicit check as last statement for implicit function returns
+            // like in function test() : string { /*NOOP*/ }
+            if (body.node.body
+              // do not add if last statement is return one
+              && (body.node.body.length === 0
+                || !body.node.body[ body.node.body.length - 1].type === "ReturnStatement")
+            ) {
+              // we do not add arguments here
+              // only "return;"
+              // assertion will be added later by code below
+              body.node.body.push( t.ReturnStatement() );
+            }
           }
         }
       }


### PR DESCRIPTION
This is a implementation for #2


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2: Add assertions when implicitly returning from a function](https://issuehunt.io/repos/71611551/issues/2)
---
</details>
<!-- /Issuehunt content-->